### PR TITLE
Mlxmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,25 @@
 NAME	= miniRT
 CC	= gcc
 RM	= rm -f
-CFLAGS	= -Wall -Werror -Wextra -Iinc -Isrc/libft -Isrc/libft/gnl
+CFLAGS = -Wall -Werror -Wextra -Iinc -Isrc/libft -Isrc/libft/gnl -IMLX42/include/MLX42
 LDFLAGS = -L src/libft -lft
 DLIB	= ./src/libft/
+DMLX	= MLX42/
+NMLX	= libmlx42.a
+ifeq ($(shell uname), Linux)
+	LIBS = $(DMLX)$(NMLX) -ldl -lglfw -pthread -lm
+else
+ifeq ($(findstring Darwin, $(shell uname)))
+	LIBS = mac
+else
+ifeq ($(shell uname), Arch)
+	LIBS = ARCH
+endif
+endif
+endif
 NLIB	= libft.a
-SRC 	= miniRT.c
+SRC 	= main.c
+#miniRT.c
 BON		=
 DSRC	= $(addprefix ./src/,$(SRC))
 DBON	= $(addprefix ./src/,$(DBON))
@@ -16,18 +30,21 @@ OBJ 	= $(DSRC:.c=.o)
 all 	:	$(NAME)
 
 $(OBJ)	:	$(ALLC)
-			$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
 $(NAME)	:	$(OBJ)
 			@make bonus -C $(DLIB)
-			@$(CC) $^ -o $@ $(CFLAGS) $(LDFLAGS)
+			@make -C $(DMLX)
+			@$(CC) $^ -o $@ $(CFLAGS) $(LDFLAGS) $(LIBS) $(DLIB)$(NLIB)
 
 clean	:
 			@make clean -C $(DLIB)
+			@make clean -C $(DMLX)
 			@$(RM) $(OBJ)
 
 fclean	:	clean
 			@make fclean -C $(DLIB)
+			@make fclean -C $(DMLX)
 			@$(RM) $(NAME)
 
 re	:	fclean $(NAME)

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,19 @@
 NAME	= miniRT
 CC	= gcc
 RM	= rm -f
-CFLAGS = -Wall -Werror -Wextra -Iinc -Isrc/libft -Isrc/libft/gnl -IMLX42/include/MLX42
+CFLAGS = -Wall -Werror -Wextra -Iinc -Isrc/libft -Isrc/libft/gnl -IMLX42/include/MLX42 -IMLX42/include/
 LDFLAGS = -L src/libft -lft
 DLIB	= ./src/libft/
 DMLX	= MLX42/
 NMLX	= libmlx42.a
 ifeq ($(shell uname), Linux)
 	LIBS = $(DMLX)$(NMLX) -ldl -lglfw -pthread -lm
-else
-ifeq ($(findstring Darwin, $(shell uname)))
-	LIBS = mac
-else
-ifeq ($(shell uname), Arch)
+else ifeq ($(findstring Darwin, $(shell uname)))
+	LIBS = $(DMLX)$(NMLX) ./MLX42/libglfw3.a -framework Cocoa -framework OpenGL -framework IOKit
+else ifeq ($(shell uname), Arch)
 	LIBS = ARCH
-endif
+else
+	$( info **** S.O no ha sido reconocido ****)
 endif
 endif
 NLIB	= libft.a

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,51 @@
+// Written by Bruh
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <MLX42.h>
+#include <miniRT.h>
+#define WIDTH 256
+#define HEIGHT 256
+
+// Exit the program as failure.
+static void ft_error(void)
+{
+	fprintf(stderr, "%s", mlx_strerror(mlx_errno));
+	exit(EXIT_FAILURE);
+}
+
+// Print the window width and height.
+static void ft_hook(void* param)
+{
+	const mlx_t* mlx = param;
+
+	printf("WIDTH: %d | HEIGHT: %d\n", mlx->width, mlx->height);
+}
+
+int32_t	main(void)
+{
+
+	// MLX allows you to define its core behaviour before startup.
+	mlx_set_setting(MLX_MAXIMIZED, true);
+	mlx_t* mlx = mlx_init(WIDTH, HEIGHT, "42Balls", true);
+	if (!mlx)
+		ft_error();
+
+	/* Do stuff */
+
+	// Create and display the image.
+	mlx_image_t* img = mlx_new_image(mlx, 256, 256);
+	if (!img || (mlx_image_to_window(mlx, img, 0, 0) < 0))
+		ft_error();
+
+	// Even after the image is being displayed, we can still modify the buffer.
+	mlx_put_pixel(img, 0, 0, 0xFF0000FF);
+
+	// Register a hook and pass mlx as an optional param.
+	// NOTE: Do this before calling mlx_loop!
+	mlx_loop_hook(mlx, ft_hook, mlx);
+	mlx_loop(mlx);
+	mlx_terminate(mlx);
+	return (EXIT_SUCCESS);
+}

--- a/src/miniRT.c
+++ b/src/miniRT.c
@@ -1,7 +1,11 @@
+//#include "MLX42/includes/MLX42/MLX42.h>"
 #include <miniRT.h>
+#include <MLX42.h>
+//#include "../inc/miniRT.h"
 
 int	main(int argc, char **argv)
 {
 	if (argc >= 0)
 		printf("%s ha sido creado exitosamente.\n", *argv);
+	
 }


### PR DESCRIPTION
Modificamos el Makefile para que, dependiendo del s.o usado añada a la compilacion de .o y el ejecutable los flags pertinentes para usar la MLX42 de CODAM. Falta añadir las flags pertinentes para Arch